### PR TITLE
fix: run plugin after all variables resolved

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,10 +12,9 @@ class AWSNaming {
         this.serverlessLog = serverless.cli.log.bind(serverless.cli)
         this.options = options
         this.hooks = {
+            'before:package:initialize': this.start.bind(this),
             'before:package:finalize': naming.fixLogGroups.bind(this)
         }
-
-        self.start()
     }
 
     start() {


### PR DESCRIPTION
Variables that have a delayed resolution will not be resolved before the plugin runs. This affects custom variables.

For example:
```yaml
  serverless-aws-resource-names:
    source: mapping.json
    variables: 
      resourceNamesPrefix: ${ssm:/path/to/service/myParam}
```
or
```yaml
  serverless-aws-resource-names:
    source: mapping.json
    variables: 
      resourceNamesPrefix: ${s3:my-env-bucket/env-prefix.txt}
```

`resourceNamesPrefix` may not be resolved before the plugin executes, so the unresolved variable string is used. I'm seeing this occur on a simple serverless file where I use a plugin to load common environment config from S3:

```yaml
service: test-app

frameworkVersion: '2'

variablesResolutionMode: 20210326

provider:
  name: aws
  runtime: nodejs14.x
  lambdaHashingVersion: 20201221
  region: eu-west-1
  stackName: ${self:custom.config.prefix}-test-app
  stage: dev
  profile: dev

functions:
  helloWorld:
    handler: helloWorld.handler

package:
  patterns:
    - '!node_modules/aws-sdk'
    - '!.serverless'
    - '!README.md'

custom:
  # reads a json file from S3
  config: ${s3obj:orgnamehere-${opt:stage, self:provider.stage}-env/config.json}
  serverless-aws-resource-names:
    source: mapping.json
    variables: 
      resourceNamesPrefix: ${self:custom.config.prefix}


plugins:
  - serverless-s3obj-variable-resolver
  - serverless-aws-resource-names
```

This is mentioned in the docs:
> Note: Variable references in the serverless instance are not resolved before a Plugin's constructor is called, so if you need these, make sure to wait to access those from your hooks.
https://www.serverless.com/framework/docs/providers/aws/guide/plugins#serverless-instance

This PR fixes this by executing the plugin on a hook as described in the docs.
